### PR TITLE
Reposition WorkerFacts watermark logos on homepage

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -405,13 +405,6 @@ export default function Index() {
 
       {/* Assessment Platform Section */}
       <section className="relative overflow-hidden py-20 px-4 bg-gradient-to-r from-blue-600 to-blue-500 text-white">
-        {/* Watermark: subtle WorkerFacts logo on the left side */}
-        <img
-          src="/workerfacts-logo.png"
-          alt=""
-          aria-hidden="true"
-          className="pointer-events-none select-none absolute left-6 top-1/2 -translate-y-1/2 opacity-10 w-[220px] sm:w-[280px] md:w-[340px] lg:w-[420px]"
-        />
         <div className="container mx-auto relative z-10">
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             <div>
@@ -436,10 +429,16 @@ export default function Index() {
               </p>
             </div>
             <div className="relative flex justify-center">
+              <img
+                src="/workerfacts-logo.png"
+                alt=""
+                aria-hidden="true"
+                className="pointer-events-none select-none absolute -right-12 top-1/2 -translate-y-1/2 opacity-10 w-64 sm:w-72 md:w-80 lg:w-96"
+              />
               <OfflineImage
                 src="/close-up-bearded-neurology-specialist-checking.jpg"
                 alt="Physiotherapist assisting patient with back pain assessment"
-                className="rounded-full shadow-2xl w-80 h-80 object-cover border-4 border-white/20"
+                className="relative z-10 rounded-full shadow-2xl w-80 h-80 object-cover border-4 border-white/20"
                 fallbackText="Healthcare Professional"
               />
             </div>
@@ -841,9 +840,15 @@ export default function Index() {
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             <div className="relative">
               <img
+                src="/workerfacts-logo.png"
+                alt=""
+                aria-hidden="true"
+                className="pointer-events-none select-none absolute -left-12 top-1/2 -translate-y-1/2 opacity-10 w-48 sm:w-56 md:w-64 lg:w-72"
+              />
+              <img
                 src="/Key_Points-min.jpg"
                 alt="Healthcare professionals collaborating with technology"
-                className="rounded-lg shadow-2xl w-full hover:shadow-3xl transition-shadow duration-300"
+                className="relative z-10 rounded-lg shadow-2xl w-full hover:shadow-3xl transition-shadow duration-300"
               />
             </div>
             <div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -835,20 +835,20 @@ export default function Index() {
       </section>
 
       {/* Key Points Section */}
-      <section className="py-20 px-4 bg-blue-600 text-white">
+      <section className="relative overflow-hidden py-20 px-4 bg-blue-600 text-white">
+        <img
+          src="/workerfacts-logo.png"
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none select-none absolute top-6 left-6 opacity-10 blur-sm w-40 sm:w-48 md:w-56 lg:w-64"
+        />
         <div className="container mx-auto">
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             <div className="relative">
               <img
-                src="/workerfacts-logo.png"
-                alt=""
-                aria-hidden="true"
-                className="pointer-events-none select-none absolute -left-12 top-1/2 -translate-y-1/2 opacity-10 w-48 sm:w-56 md:w-64 lg:w-72"
-              />
-              <img
                 src="/Key_Points-min.jpg"
                 alt="Healthcare professionals collaborating with technology"
-                className="relative z-10 rounded-lg shadow-2xl w-full hover:shadow-3xl transition-shadow duration-300"
+                className="rounded-lg shadow-2xl w-full hover:shadow-3xl transition-shadow duration-300"
               />
             </div>
             <div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -840,9 +840,9 @@ export default function Index() {
           src="/workerfacts-logo.png"
           alt=""
           aria-hidden="true"
-          className="pointer-events-none select-none absolute top-6 left-6 opacity-10 blur-sm w-40 sm:w-48 md:w-56 lg:w-64"
+          className="pointer-events-none select-none absolute top-6 left-6 opacity-10 w-64 sm:w-72 md:w-80 lg:w-96"
         />
-        <div className="container mx-auto">
+        <div className="container mx-auto relative z-10">
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             <div className="relative">
               <img


### PR DESCRIPTION
## Purpose
The user wanted to improve the positioning of the WorkerFacts logo watermarks on the homepage. They requested moving the watermark to the right of the first picture on the blue background section, and adding another watermark to the left of the second picture. The second watermark needed to be positioned at the top left and made more visible while maintaining the same blurred appearance as the first one.

## Code changes
- **Removed** the original left-positioned watermark from the Assessment Platform section
- **Added** a new watermark positioned to the right of the first image in the Assessment Platform section with `-right-12` positioning
- **Added** `relative z-10` class to the first image to ensure proper layering
- **Added** a new watermark in the Key Points section positioned at the top left with `top-6 left-6`
- **Added** `relative overflow-hidden` classes and `relative z-10` to the Key Points section container for proper positioning and layering
- Both watermarks maintain consistent styling with `opacity-10` and responsive sizing

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cffc0db5b26d4101b1ce2e5cc049c18c/swoosh-sanctuary)

👀 [Preview Link](https://cffc0db5b26d4101b1ce2e5cc049c18c-swoosh-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cffc0db5b26d4101b1ce2e5cc049c18c</projectId>-->
<!--<branchName>swoosh-sanctuary</branchName>-->