### PR TITLE
Disable pay step after Stripe success and set test amount to $1

### DIFF
--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -258,7 +258,7 @@ export default function Dashboard() {
           if (isDemoMode && !forceReal) {
             navigate("/payment");
           } else {
-            startCheckout({ amount: 25, currency: "USD" }).catch((e: any) => {
+            startCheckout({ amount: 1, currency: "USD" }).catch((e: any) => {
               console.error(e);
               toast({
                 title: "Payment error",

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -65,6 +65,7 @@ export default function Dashboard() {
   const [showLogoutDialog, setShowLogoutDialog] = useState(false);
   const [showBackDialog, setShowBackDialog] = useState(false);
   const [completedSteps, setCompletedSteps] = useState<number[]>([]);
+  const [stripePaid, setStripePaid] = useState(false);
 
   const workflowSteps: WorkflowStep[] = [
     {
@@ -155,7 +156,11 @@ export default function Dashboard() {
       completedStepsArray = JSON.parse(savedCompletedSteps);
     }
 
-    // If returned from Stripe success, mark payment step as completed
+    // Restore Stripe payment success state
+    const savedStripe = localStorage.getItem("stripePaymentSuccess") === "1";
+    if (savedStripe) setStripePaid(true);
+
+    // If returned from Stripe success, mark payment step as completed and persist flag
     const params = new URLSearchParams(window.location.search);
     if (params.get("paid") === "1" && !completedStepsArray.includes(8)) {
       completedStepsArray.push(8);
@@ -163,6 +168,8 @@ export default function Dashboard() {
         "completedSteps",
         JSON.stringify(completedStepsArray),
       );
+      localStorage.setItem("stripePaymentSuccess", "1");
+      setStripePaid(true);
       // Clean URL param
       const url = new URL(window.location.href);
       url.searchParams.delete("paid");
@@ -280,6 +287,9 @@ export default function Dashboard() {
   const isStepAvailable = (stepId: number) => {
     // Step 1 is always available
     if (stepId === 1) return true;
+
+    // Disable Pay step if Stripe checkout already succeeded
+    if (stepId === 8 && stripePaid) return false;
 
     // Other steps are available only if previous step is completed
     return completedSteps.includes(stepId - 1);


### PR DESCRIPTION
## Purpose
The user requested two main changes to the payment flow:
1. Disable the payment step in the dashboard once a user has successfully completed Stripe checkout
2. Temporarily reduce the checkout amount from $25 to $1 for testing payment functionality before going live

## Code changes
- **Payment step disabling**: Added `stripePaid` state and localStorage persistence to track successful Stripe payments and prevent re-payment
- **Amount reduction**: Changed checkout amount from $25 to $1 in the `startCheckout` call for testing purposes
- **State management**: Enhanced the dashboard to restore and maintain Stripe payment success state across page reloads
- **Step availability logic**: Updated `isStepAvailable` function to disable step 8 (payment) when `stripePaid` is true

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/84f39e3a51604fbd850f54f7f0f7552d/cosmos-field)

👀 [Preview Link](https://84f39e3a51604fbd850f54f7f0f7552d-cosmos-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>84f39e3a51604fbd850f54f7f0f7552d</projectId>-->
<!--<branchName>cosmos-field</branchName>-->